### PR TITLE
Add timeout for http request

### DIFF
--- a/app/src/main/java/org/kontalk/client/ClientHTTPConnection.java
+++ b/app/src/main/java/org/kontalk/client/ClientHTTPConnection.java
@@ -18,35 +18,6 @@
 
 package org.kontalk.client;
 
-import android.content.Context;
-import android.util.Log;
-
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.params.ClientPNames;
-import org.apache.http.conn.ClientConnectionManager;
-import org.apache.http.conn.scheme.PlainSocketFactory;
-import org.apache.http.conn.scheme.Scheme;
-import org.apache.http.conn.scheme.SchemeRegistry;
-import org.apache.http.conn.ssl.SSLSocketFactory;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.impl.conn.SingleClientConnManager;
-import org.apache.http.params.BasicHttpParams;
-import org.apache.http.params.HttpConnectionParams;
-import org.apache.http.params.HttpParams;
-import org.apache.http.util.EntityUtils;
-import org.kontalk.message.CompositeMessage;
-import org.kontalk.service.DownloadListener;
-import org.kontalk.util.InternalTrustStore;
-import org.kontalk.util.MediaStorage;
-import org.kontalk.util.Preferences;
-import org.kontalk.util.ProgressOutputStreamEntity;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -72,6 +43,34 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.params.ClientPNames;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.conn.scheme.PlainSocketFactory;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.SingleClientConnManager;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpParams;
+import org.apache.http.util.EntityUtils;
+
+import org.kontalk.message.CompositeMessage;
+import org.kontalk.service.DownloadListener;
+import org.kontalk.util.InternalTrustStore;
+import org.kontalk.util.MediaStorage;
+import org.kontalk.util.Preferences;
+import org.kontalk.util.ProgressOutputStreamEntity;
+
+import android.content.Context;
+import android.util.Log;
 
 /**
  * FIXME this is actually specific to Kontalk Dropbox server.
@@ -91,6 +90,8 @@ public class ClientHTTPConnection {
 
     private HttpRequestBase currentRequest;
     private HttpClient mConnection;
+    private final static int CONNECT_TIMEOUT = 15000;
+    private final static int READ_TIMEOUT = 40000;
 
     public ClientHTTPConnection(Context context, PrivateKey privateKey, X509Certificate bridgeCert) {
         mContext = context;
@@ -165,8 +166,8 @@ public class ClientHTTPConnection {
                 // HttpClient bug caused by Lighttpd
                 params.setBooleanParameter("http.protocol.expect-continue", false);
 
-                HttpConnectionParams.setConnectionTimeout(params, 10000);
-                HttpConnectionParams.setSoTimeout(params, 40000);
+                HttpConnectionParams.setConnectionTimeout(params, CONNECT_TIMEOUT);
+                HttpConnectionParams.setSoTimeout(params, READ_TIMEOUT);
                 // create connection manager
                 ClientConnectionManager connMgr = new SingleClientConnManager(params, registry);
 

--- a/app/src/main/java/org/kontalk/client/ClientHTTPConnection.java
+++ b/app/src/main/java/org/kontalk/client/ClientHTTPConnection.java
@@ -61,6 +61,7 @@ import org.apache.http.impl.conn.SingleClientConnManager;
 import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.util.EntityUtils;
+import org.apache.http.params.HttpConnectionParams;
 
 import org.kontalk.message.CompositeMessage;
 import org.kontalk.service.DownloadListener;

--- a/app/src/main/java/org/kontalk/client/ClientHTTPConnection.java
+++ b/app/src/main/java/org/kontalk/client/ClientHTTPConnection.java
@@ -18,6 +18,35 @@
 
 package org.kontalk.client;
 
+import android.content.Context;
+import android.util.Log;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.params.ClientPNames;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.conn.scheme.PlainSocketFactory;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.SingleClientConnManager;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpConnectionParams;
+import org.apache.http.params.HttpParams;
+import org.apache.http.util.EntityUtils;
+import org.kontalk.message.CompositeMessage;
+import org.kontalk.service.DownloadListener;
+import org.kontalk.util.InternalTrustStore;
+import org.kontalk.util.MediaStorage;
+import org.kontalk.util.Preferences;
+import org.kontalk.util.ProgressOutputStreamEntity;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -42,35 +71,6 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
-
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.params.ClientPNames;
-import org.apache.http.conn.ClientConnectionManager;
-import org.apache.http.conn.scheme.PlainSocketFactory;
-import org.apache.http.conn.scheme.Scheme;
-import org.apache.http.conn.scheme.SchemeRegistry;
-import org.apache.http.conn.ssl.SSLSocketFactory;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.impl.conn.SingleClientConnManager;
-import org.apache.http.params.BasicHttpParams;
-import org.apache.http.params.HttpParams;
-import org.apache.http.util.EntityUtils;
-
-import org.kontalk.message.CompositeMessage;
-import org.kontalk.service.DownloadListener;
-import org.kontalk.util.InternalTrustStore;
-import org.kontalk.util.MediaStorage;
-import org.kontalk.util.Preferences;
-import org.kontalk.util.ProgressOutputStreamEntity;
-
-import android.content.Context;
-import android.util.Log;
 
 
 /**
@@ -165,6 +165,8 @@ public class ClientHTTPConnection {
                 // HttpClient bug caused by Lighttpd
                 params.setBooleanParameter("http.protocol.expect-continue", false);
 
+                HttpConnectionParams.setConnectionTimeout(params, 10000);
+                HttpConnectionParams.setSoTimeout(params, 40000);
                 // create connection manager
                 ClientConnectionManager connMgr = new SingleClientConnManager(params, registry);
 

--- a/app/src/main/java/org/kontalk/upload/KontalkBoxUploadConnection.java
+++ b/app/src/main/java/org/kontalk/upload/KontalkBoxUploadConnection.java
@@ -18,9 +18,14 @@
 
 package org.kontalk.upload;
 
-import android.content.Context;
-import android.content.res.AssetFileDescriptor;
-import android.net.Uri;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.List;
 
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
@@ -41,9 +46,13 @@ import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.SingleClientConnManager;
 import org.apache.http.params.BasicHttpParams;
-import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.util.EntityUtils;
+
+import android.content.Context;
+import android.content.res.AssetFileDescriptor;
+import android.net.Uri;
+
 import org.kontalk.Kontalk;
 import org.kontalk.client.ClientHTTPConnection;
 import org.kontalk.client.EndpointServer;
@@ -53,16 +62,6 @@ import org.kontalk.provider.UsersProvider;
 import org.kontalk.service.ProgressListener;
 import org.kontalk.util.Preferences;
 import org.kontalk.util.ProgressInputStreamEntity;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.security.PrivateKey;
-import java.security.cert.X509Certificate;
-import java.util.List;
-
 
 /**
  * Upload service implementation for Kontalk Box dropbox service.
@@ -82,6 +81,8 @@ public class KontalkBoxUploadConnection implements UploadConnection {
 
     protected HttpRequestBase currentRequest;
     protected HttpClient mConnection;
+	private final static int CONNECT_TIMEOUT = 15000;
+    private final static int READ_TIMEOUT = 40000;
 
     private final PrivateKey mPrivateKey;
     private final X509Certificate mCertificate;
@@ -250,8 +251,8 @@ public class KontalkBoxUploadConnection implements UploadConnection {
                 // HttpClient bug caused by Lighttpd
                 params.setBooleanParameter("http.protocol.expect-continue", false);
 
-                HttpConnectionParams.setConnectionTimeout(params, 10000);
-                HttpConnectionParams.setSoTimeout(params, 40000);
+                HttpConnectionParams.setConnectionTimeout(params, CONNECT_TIMEOUT);
+                HttpConnectionParams.setSoTimeout(params, READ_TIMEOUT);
                 // create connection manager
                 ClientConnectionManager connMgr = new SingleClientConnManager(params, registry);
 

--- a/app/src/main/java/org/kontalk/upload/KontalkBoxUploadConnection.java
+++ b/app/src/main/java/org/kontalk/upload/KontalkBoxUploadConnection.java
@@ -18,14 +18,9 @@
 
 package org.kontalk.upload;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.security.PrivateKey;
-import java.security.cert.X509Certificate;
-import java.util.List;
+import android.content.Context;
+import android.content.res.AssetFileDescriptor;
+import android.net.Uri;
 
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
@@ -46,13 +41,9 @@ import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.SingleClientConnManager;
 import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.util.EntityUtils;
-
-import android.content.Context;
-import android.content.res.AssetFileDescriptor;
-import android.net.Uri;
-
 import org.kontalk.Kontalk;
 import org.kontalk.client.ClientHTTPConnection;
 import org.kontalk.client.EndpointServer;
@@ -62,6 +53,15 @@ import org.kontalk.provider.UsersProvider;
 import org.kontalk.service.ProgressListener;
 import org.kontalk.util.Preferences;
 import org.kontalk.util.ProgressInputStreamEntity;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.List;
 
 
 /**
@@ -250,6 +250,8 @@ public class KontalkBoxUploadConnection implements UploadConnection {
                 // HttpClient bug caused by Lighttpd
                 params.setBooleanParameter("http.protocol.expect-continue", false);
 
+                HttpConnectionParams.setConnectionTimeout(params, 10000);
+                HttpConnectionParams.setSoTimeout(params, 40000);
                 // create connection manager
                 ClientConnectionManager connMgr = new SingleClientConnManager(params, registry);
 

--- a/app/src/main/java/org/kontalk/upload/KontalkBoxUploadConnection.java
+++ b/app/src/main/java/org/kontalk/upload/KontalkBoxUploadConnection.java
@@ -48,6 +48,7 @@ import org.apache.http.impl.conn.SingleClientConnManager;
 import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.util.EntityUtils;
+import org.apache.http.params.HttpConnectionParams;
 
 import android.content.Context;
 import android.content.res.AssetFileDescriptor;
@@ -81,7 +82,7 @@ public class KontalkBoxUploadConnection implements UploadConnection {
 
     protected HttpRequestBase currentRequest;
     protected HttpClient mConnection;
-	private final static int CONNECT_TIMEOUT = 15000;
+    private final static int CONNECT_TIMEOUT = 15000;
     private final static int READ_TIMEOUT = 40000;
 
     private final PrivateKey mPrivateKey;


### PR DESCRIPTION
Hi,

The timeout of HttpURLConnection and Apache HttpClient is 0, which means the request would never return if either connection or read timeouts, and the code would never catch these exceptions.

This patch set explicit timeout value (10s for connection timeout and 40s for read timeout), so the code would catch and handle timeout exceptions as you would expect.

Best,