### PR TITLE
Toolbar shadow

### DIFF
--- a/app/src/main/res/layout/toolbar_simple.xml
+++ b/app/src/main/res/layout/toolbar_simple.xml
@@ -16,13 +16,13 @@
      along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
 
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-    <android.support.v7.widget.Toolbar
-        android:id="@+id/toolbar"
-        android:layout_height="?attr/actionBarSize"
-        android:layout_width="match_parent"
-        android:background="?attr/colorPrimary"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>
-</merge>
+<android.support.v7.widget.Toolbar
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/toolbar"
+    android:layout_height="?attr/actionBarSize"
+    android:layout_width="match_parent"
+    android:background="?attr/colorPrimary"
+    android:elevation="4dp"
+    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+    app:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -33,6 +33,7 @@
     <item name="colorAccent">@color/app_accent</item>
 
     <item name="windowActionModeOverlay">true</item>
+    <item name="android:windowContentOverlay">@null</item>
   </style>
 
 </resources>


### PR DESCRIPTION
Toolbar should have a shadow according to the [spec](https://www.google.com/design/spec/what-is-material/elevation-shadows.html#elevation-shadows-shadows). Unfortunately elevation is supported only since Android Lollipop.

Before and after on Marshmallow:

![toolbar-m](https://cloud.githubusercontent.com/assets/8256809/15452564/ae711c1c-2004-11e6-92b4-643be7e74fe0.png)

Before and after on Jelly Bean (no shadow below the status bar):

![toolbar-jb](https://cloud.githubusercontent.com/assets/8256809/15452563/9701da44-2004-11e6-8823-64227d97351c.png)
